### PR TITLE
handle value is null for formatNumber in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ const ora = require('ora');
  * @returns 
  */
 function formatNumber(value, decimals = 0, sign = false) {
+	if (value == null)
+		value = 0.0;
+		
 	let res = Number(value.toFixed(decimals)).toLocaleString();
 	if (sign && value > 0.0)
 		res = "+" + res;

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const ora = require('ora');
  */
 function formatNumber(value, decimals = 0, sign = false) {
 	if (value == null)
-		value = 0.0;
+		return "-";
 		
 	let res = Number(value.toFixed(decimals)).toLocaleString();
 	if (sign && value > 0.0)


### PR DESCRIPTION
possible bug: in the function of "formatNumber" in index.js, when value is null, it throw an unhandle rejection typeerror 

Hi, I was running this benchmarkify to test validator.js with the test case I generated symbolically. It triggered an unhandled rejection type error in formatNumber function. I was wondering if this should be a null value check for this error. It only needs a simple fix(see my pull request please). but if this is a real unhandle error, it would be a finding of the symbolic execution experiment. Please let me know.

exception throwed as below:
![image](https://user-images.githubusercontent.com/32209826/94300451-dfacce00-ff1d-11ea-9eb2-d577e2f9bd98.png)
